### PR TITLE
Tap menu items without a service tag will be ignored.

### DIFF
--- a/source/HomeAssistantApp.mc
+++ b/source/HomeAssistantApp.mc
@@ -138,7 +138,7 @@ class HomeAssistantApp extends Application.AppBase {
 
     function fetchMenuConfig() as Void {
         var options = {
-            :method  => Communications.HTTP_REQUEST_METHOD_GET,
+            :method       => Communications.HTTP_REQUEST_METHOD_GET,
             :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON
         };
         Communications.makeWebRequest(

--- a/source/HomeAssistantMenuItem.mc
+++ b/source/HomeAssistantMenuItem.mc
@@ -32,11 +32,11 @@ class HomeAssistantMenuItem extends WatchUi.MenuItem {
     hidden var mService            as Lang.String;
 
     function initialize(
-        label as Lang.String or Lang.Symbol,
-        subLabel as Lang.String or Lang.Symbol or Null,
+        label      as Lang.String or Lang.Symbol,
+        subLabel   as Lang.String or Lang.Symbol or Null,
         identifier as Lang.Object or Null,
-        service as Lang.String or Null,
-        options as {
+        service    as Lang.String or Null,
+        options    as {
             :alignment as WatchUi.MenuItem.Alignment,
             :icon      as Graphics.BitmapType or WatchUi.Drawable or Lang.Symbol
         } or Null

--- a/source/HomeAssistantToggleMenuItem.mc
+++ b/source/HomeAssistantToggleMenuItem.mc
@@ -31,16 +31,16 @@ class HomeAssistantToggleMenuItem extends WatchUi.ToggleMenuItem {
     hidden var strUnhandledHttpErr as Lang.String;
 
     function initialize(
-        label as Lang.String or Lang.Symbol,
+        label    as Lang.String or Lang.Symbol,
         subLabel as Lang.String or Lang.Symbol or {
             :enabled  as Lang.String or Lang.Symbol or Null,
             :disabled as Lang.String or Lang.Symbol or Null
         } or Null,
         identifier,
-        enabled as Lang.Boolean,
-        options as {
+        enabled  as Lang.Boolean,
+        options  as {
             :alignment as WatchUi.MenuItem.Alignment,
-            :icon as Graphics.BitmapType or WatchUi.Drawable or Lang.Symbol
+            :icon      as Graphics.BitmapType or WatchUi.Drawable or Lang.Symbol
         } or Null
     ) {
         strNoInternet       = WatchUi.loadResource($.Rez.Strings.NoInternet);

--- a/source/HomeAssistantView.mc
+++ b/source/HomeAssistantView.mc
@@ -68,7 +68,7 @@ class HomeAssistantView extends WatchUi.Menu2 {
                     );
                     addItem(item);
                     mListToggleItems.add(item);
-                } else if (type.equals("tap")) {
+                } else if (type.equals("tap") && service != null) {
                     addItem(
                         new HomeAssistantMenuItem(
                             name,


### PR DESCRIPTION
The JSON schema checker is relied on to highlight this error.