### PR TITLE
Refactored own class for receiving app properties

### DIFF
--- a/source/HomeAssistantApp.mc
+++ b/source/HomeAssistantApp.mc
@@ -63,9 +63,9 @@ class HomeAssistantApp extends Application.AppBase {
 
     // Return the initial view of your application here
     function getInitialView() as Lang.Array<WatchUi.Views or WatchUi.InputDelegates>? {
-        var api_url = Properties.getValue("api_url") as Lang.String;
+        var api_url = Settings.get().apiUrl();
 
-        if ((Properties.getValue("api_key") as Lang.String).length() == 0) {
+        if (Settings.get().apiKey().length() == 0) {
             if (Globals.scDebug) {
                 System.println("HomeAssistantApp getInitialView(): No API key in the application settings.");
             }
@@ -80,7 +80,7 @@ class HomeAssistantApp extends Application.AppBase {
                 System.println("HomeAssistantApp getInitialView(): API URL must not have a trailing slash '/'.");
             }
             return [new ErrorView(strTrailingSlashErr + "."), new ErrorDelegate()] as Lang.Array<WatchUi.Views or WatchUi.InputDelegates>;
-        } else if ((Properties.getValue("config_url") as Lang.String).length() == 0) {
+        } else if (Settings.get().configUrl().length() == 0) {
             if (Globals.scDebug) {
                 System.println("HomeAssistantApp getInitialView(): No configuration URL in the application settings.");
             }
@@ -159,7 +159,7 @@ class HomeAssistantApp extends Application.AppBase {
             :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON
         };
         Communications.makeWebRequest(
-            Properties.getValue("config_url"),
+            Settings.get().configUrl(),
             null,
             options,
             method(:onReturnFetchMenuConfig)

--- a/source/HomeAssistantMenuItemFactory.mc
+++ b/source/HomeAssistantMenuItemFactory.mc
@@ -26,7 +26,6 @@ class HomeAssistantMenuItemFactory {
     private var mMenuItemOptions          as Lang.Dictionary;
     private var mLabelToggle              as Lang.Dictionary;
     private var strMenuItemTap            as Lang.String;
-    private var bRepresentTypesWithLabels as Lang.Boolean;
     private var mTapTypeIcon              as WatchUi.Bitmap;
     private var mGroupTypeIcon            as WatchUi.Bitmap;
     private var mHomeAssistantService     as HomeAssistantService;
@@ -38,10 +37,8 @@ class HomeAssistantMenuItemFactory {
             :enabled  => WatchUi.loadResource($.Rez.Strings.MenuItemOn)  as Lang.String,
             :disabled => WatchUi.loadResource($.Rez.Strings.MenuItemOff) as Lang.String
         };
-        bRepresentTypesWithLabels = Application.Properties.getValue("types_representation") as Lang.Boolean;
 
-        var menuItemAlignment = Application.Properties.getValue("menu_alignment") as Lang.Boolean;
-        if(menuItemAlignment){
+        if(Settings.get().menuItemAlignmentRight()){
             mMenuItemOptions = {
                 :alignment => WatchUi.MenuItem.MENU_ITEM_LABEL_ALIGN_RIGHT
             };
@@ -76,7 +73,7 @@ class HomeAssistantMenuItemFactory {
     function toggle(label as Lang.String or Lang.Symbol, identifier as Lang.Object or Null) as WatchUi.MenuItem {
         var subLabel = null;
 
-        if (bRepresentTypesWithLabels == true){
+        if (Settings.get().showTypeLabels()){
             subLabel=mLabelToggle;
         }
      
@@ -90,7 +87,7 @@ class HomeAssistantMenuItemFactory {
     }
 
     function tap(label as Lang.String or Lang.Symbol, identifier as Lang.Object or Null, service as Lang.String or Null) as WatchUi.MenuItem {
-        if (bRepresentTypesWithLabels) {
+        if (Settings.get().showTypeLabels()) {
             return new HomeAssistantMenuItem(
                 label,
                 strMenuItemTap,
@@ -113,7 +110,7 @@ class HomeAssistantMenuItemFactory {
     }
 
     function group(definition as Lang.Dictionary) as WatchUi.MenuItem {
-        if (bRepresentTypesWithLabels) {
+        if (Settings.get().showTypeLabels()) {
             return new HomeAssistantViewMenuItem(definition);
         } else {
             return new HomeAssistantViewIconMenuItem(definition, mGroupTypeIcon, mMenuItemOptions);

--- a/source/HomeAssistantService.mc
+++ b/source/HomeAssistantService.mc
@@ -24,7 +24,6 @@ using Toybox.Graphics;
 using Toybox.Application.Properties;
 
 class HomeAssistantService {
-    private var mApiKey             as Lang.String;
     private var strNoPhone          as Lang.String;
     private var strNoInternet       as Lang.String;
     private var strNoResponse       as Lang.String;
@@ -39,7 +38,6 @@ class HomeAssistantService {
         strApiFlood         = WatchUi.loadResource($.Rez.Strings.ApiFlood);
         strApiUrlNotFound   = WatchUi.loadResource($.Rez.Strings.ApiUrlNotFound);
         strUnhandledHttpErr = WatchUi.loadResource($.Rez.Strings.UnhandledHttpErr);
-        mApiKey             = Properties.getValue("api_key");
     }
 
     // Callback function after completing the POST request to call a service.
@@ -108,7 +106,7 @@ class HomeAssistantService {
             :method  => Communications.HTTP_REQUEST_METHOD_POST,
             :headers => {
                 "Content-Type"  => Communications.REQUEST_CONTENT_TYPE_JSON,
-                "Authorization" => "Bearer " + mApiKey
+                "Authorization" => "Bearer " + Settings.get().apiKey()
             },
             :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON,
             :context      => identifier
@@ -124,7 +122,7 @@ class HomeAssistantService {
             }
             WatchUi.pushView(new ErrorView(strNoInternet + "."), new ErrorDelegate(), WatchUi.SLIDE_UP);
         } else {
-            var url = (Properties.getValue("api_url") as Lang.String) + "/services/" + service.substring(0, service.find(".")) + "/" + service.substring(service.find(".")+1, null);
+            var url = Settings.get().apiUrl() + "/services/" + service.substring(0, service.find(".")) + "/" + service.substring(service.find(".")+1, null);
             if (Globals.scDebug) {
                 System.println("HomeAssistantService call() URL=" + url);
                 System.println("HomeAssistantService call() service=" + service);

--- a/source/HomeAssistantToggleMenuItem.mc
+++ b/source/HomeAssistantToggleMenuItem.mc
@@ -25,7 +25,6 @@ using Toybox.Application.Properties;
 using Toybox.Timer;
 
 class HomeAssistantToggleMenuItem extends WatchUi.ToggleMenuItem {
-    private var mApiKey             as Lang.String;
     private var strNoPhone          as Lang.String;
     private var strNoInternet       as Lang.String;
     private var strNoResponse       as Lang.String;
@@ -52,7 +51,6 @@ class HomeAssistantToggleMenuItem extends WatchUi.ToggleMenuItem {
         strApiFlood         = WatchUi.loadResource($.Rez.Strings.ApiFlood);
         strApiUrlNotFound   = WatchUi.loadResource($.Rez.Strings.ApiUrlNotFound);
         strUnhandledHttpErr = WatchUi.loadResource($.Rez.Strings.UnhandledHttpErr);
-        mApiKey             = Properties.getValue("api_key");
         WatchUi.ToggleMenuItem.initialize(label, subLabel, identifier, enabled, options);
     }
 
@@ -138,7 +136,7 @@ class HomeAssistantToggleMenuItem extends WatchUi.ToggleMenuItem {
         var options = {
             :method  => Communications.HTTP_REQUEST_METHOD_GET,
             :headers => {
-                "Authorization" => "Bearer " + mApiKey
+                "Authorization" => "Bearer " + Settings.get().apiKey()
             },
             :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON
         };
@@ -160,7 +158,7 @@ class HomeAssistantToggleMenuItem extends WatchUi.ToggleMenuItem {
                 WatchUi.pushView(new ErrorView(strNoInternet + "."), new ErrorDelegate(), WatchUi.SLIDE_UP);
             }
         } else {
-            var url = Properties.getValue("api_url") + "/states/" + mIdentifier;
+            var url = Settings.get().apiUrl() + "/states/" + mIdentifier;
             if (Globals.scDebug) {
                 System.println("HomeAssistantToggleMenuItem getState() URL=" + url);
             }
@@ -236,7 +234,7 @@ class HomeAssistantToggleMenuItem extends WatchUi.ToggleMenuItem {
             :method  => Communications.HTTP_REQUEST_METHOD_POST,
             :headers => {
                 "Content-Type"  => Communications.REQUEST_CONTENT_TYPE_JSON,
-                "Authorization" => "Bearer " + mApiKey
+                "Authorization" => "Bearer " + Settings.get().apiKey()
             },
             :responseType => Communications.HTTP_RESPONSE_CONTENT_TYPE_JSON
         };
@@ -260,9 +258,9 @@ class HomeAssistantToggleMenuItem extends WatchUi.ToggleMenuItem {
             var id = mIdentifier as Lang.String;
             var url;
             if (s) {
-                url = Properties.getValue("api_url") + "/services/" + id.substring(0, id.find(".")) + "/turn_on";
+                url = Settings.get().apiUrl() + "/services/" + id.substring(0, id.find(".")) + "/turn_on";
             } else {
-                url = Properties.getValue("api_url") + "/services/" + id.substring(0, id.find(".")) + "/turn_off";
+                url = Settings.get().apiUrl() + "/services/" + id.substring(0, id.find(".")) + "/turn_off";
             }
             if (Globals.scDebug) {
                 System.println("HomeAssistantToggleMenuItem setState() URL=" + url);

--- a/source/Settings.mc
+++ b/source/Settings.mc
@@ -46,23 +46,23 @@ class Settings {
         return instance;
     }
 
-    function apiKey() as Lang.String{
+    function apiKey() as Lang.String {
         return strApiKey;
     }
 
-    function apiUrl() as Lang.String{
+    function apiUrl() as Lang.String {
         return strApiUrl;
     }
 
-    function configUrl() as Lang.String{
+    function configUrl() as Lang.String {
         return strConfigUrl;
     }
 
-    function menuItemAlignmentRight() as Lang.Boolean{
+    function menuItemAlignmentRight() as Lang.Boolean {
         return bMenuItemAlignmentRight;
     }
 
-    function showTypeLabels() as Lang.Boolean{
+    function showTypeLabels() as Lang.Boolean {
         return bRepresentTypesWithLabels;
     }
 }

--- a/source/Settings.mc
+++ b/source/Settings.mc
@@ -1,0 +1,68 @@
+//-----------------------------------------------------------------------------------
+//
+// Distributed under MIT Licence
+//   See https://github.com/house-of-abbey/GarminHomeAssistant/blob/main/LICENSE.
+//
+//-----------------------------------------------------------------------------------
+//
+// GarminHomeAssistant is a Garmin IQ application written in Monkey C and routinely
+// tested on a Venu 2 device. The source code is provided at:
+//            https://github.com/house-of-abbey/GarminHomeAssistant.
+//
+// P A Abbey & J D Abbey, SomeoneOnEarth, 23 November 2023
+//
+//
+// Description:
+//
+// Home Assistant settings.
+//
+//-----------------------------------------------------------------------------------
+
+using Toybox.Lang;
+using Toybox.Application.Properties;
+
+class Settings {
+
+    private static var instance;
+
+    private var strApiKey                 as Lang.String;
+    private var strApiUrl                 as Lang.String;
+    private var strConfigUrl              as Lang.String;
+    private var bRepresentTypesWithLabels as Lang.Boolean;
+    private var bMenuItemAlignmentRight   as Lang.Boolean;
+
+    private function initialize() {
+        strApiKey                 = Properties.getValue("api_key");
+        strApiUrl                 = Properties.getValue("api_url");
+        strConfigUrl              = Properties.getValue("config_url");
+        bRepresentTypesWithLabels = Properties.getValue("types_representation");
+        bMenuItemAlignmentRight   = Properties.getValue("menu_alignment");
+    }
+
+    static function get() as Settings {
+        if (instance == null) {
+            instance = new Settings();
+        }
+        return instance;
+    }
+
+    function apiKey() as Lang.String{
+        return strApiKey;
+    }
+
+    function apiUrl() as Lang.String{
+        return strApiUrl;
+    }
+
+    function configUrl() as Lang.String{
+        return strConfigUrl;
+    }
+
+    function menuItemAlignmentRight() as Lang.Boolean{
+        return bMenuItemAlignmentRight;
+    }
+
+    function showTypeLabels() as Lang.Boolean{
+        return bRepresentTypesWithLabels;
+    }
+}


### PR DESCRIPTION
Hello!

Refactoring for encapsulation of Properties.getValue() calls into one place.

- cleaner code
- remove redundant / duplicate code
- much easier to set properties for local on-the-device testing (main purpose for this refactoring)

Have fun,
 someone