### PR TITLE
Auto close confirmation dialog after timeout

### DIFF
--- a/resources/settings/properties.xml
+++ b/resources/settings/properties.xml
@@ -30,6 +30,12 @@
   -->
   <property id="app_timeout" type="number">0</property>
 
+  <!--
+    After this time (in seconds), a confirmation dialog for an action is automatically closed and the action is cancelled.
+    Set to 0 to disable the timeout. The default value is 3 seconds.
+  -->
+  <property id="confirm_timeout" type="number">3</property>
+
   <property id="types_representation" type="boolean"></property>
 
   <property id="menu_alignment" type="boolean"></property>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -54,6 +54,16 @@
   </setting>
 
   <setting
+    propertyKey="@Properties.confirm_timeout"
+    title="After this time (in seconds), a confirmation dialog for an action is automatically closed and the action is cancelled. Set to 0 to disable the timeout."
+  >
+    <settingConfig
+      type="numeric"
+      min="0"
+    />
+  </setting>
+
+  <setting
     propertyKey="@Properties.types_representation"
     title="Representing types with icons (off) or with labels (on)"
   >

--- a/source/HomeAssistantConfirmation.mc
+++ b/source/HomeAssistantConfirmation.mc
@@ -22,9 +22,9 @@ using Toybox.Lang;
 // Required for callback method definition
 typedef Method as Toybox.Lang.Method;
 using Toybox.WatchUi;
+using Toybox.Timer;
 
 class HomeAssistantConfirmation extends WatchUi.Confirmation {
-
     function initialize() {
         WatchUi.Confirmation.initialize(WatchUi.loadResource($.Rez.Strings.Confirm));
     }
@@ -33,17 +33,26 @@ class HomeAssistantConfirmation extends WatchUi.Confirmation {
 
 class HomeAssistantConfirmationDelegate extends WatchUi.ConfirmationDelegate {
     private var confirmMethod;
+    private var timeout;
 
     function initialize(callback as Method() as Void) {
         WatchUi.ConfirmationDelegate.initialize();
         confirmMethod = callback;
+        timeout = new Timer.Timer();
+        timeout.start(method(:onTimeout), 3000, true);
     }
 
     function onResponse(response) as Lang.Boolean {
         getApp().getQuitTimer().reset();
+        timeout.stop();
         if (response == WatchUi.CONFIRM_YES) {
             confirmMethod.invoke();
         }
         return true;
+    }
+
+    function onTimeout() as Void {
+        timeout.stop();
+        WatchUi.popView(WatchUi.SLIDE_RIGHT);
     }
 }

--- a/source/HomeAssistantConfirmation.mc
+++ b/source/HomeAssistantConfirmation.mc
@@ -23,6 +23,7 @@ using Toybox.Lang;
 typedef Method as Toybox.Lang.Method;
 using Toybox.WatchUi;
 using Toybox.Timer;
+using Toybox.Application.Properties;
 
 class HomeAssistantConfirmation extends WatchUi.Confirmation {
     function initialize() {
@@ -38,13 +39,18 @@ class HomeAssistantConfirmationDelegate extends WatchUi.ConfirmationDelegate {
     function initialize(callback as Method() as Void) {
         WatchUi.ConfirmationDelegate.initialize();
         confirmMethod = callback;
-        timeout = new Timer.Timer();
-        timeout.start(method(:onTimeout), 3000, true);
+        var timeoutSeconds = Properties.getValue("confirm_timeout") as Lang.Number; 
+        if (timeoutSeconds > 0) {
+            timeout = new Timer.Timer();
+            timeout.start(method(:onTimeout), timeoutSeconds * 1000, true);
+        }
     }
 
     function onResponse(response) as Lang.Boolean {
         getApp().getQuitTimer().reset();
-        timeout.stop();
+        if (timeout) {
+            timeout.stop();
+        }
         if (response == WatchUi.CONFIRM_YES) {
             confirmMethod.invoke();
         }


### PR DESCRIPTION
Hello and thank you for your work on this project!
I have recently started using the app on my Garmin watch.

I find the confirmation function very important as I don't want to accidentally trigger actions like opening the front door.

To make the whole thing even more secure against accidental operation, I have added a timeout after which the confirmation dialog closes automatically. The timeout is currently hardcoded to 3 seconds, but can of course be configured if required.

 I hope you find this usefull as well.