### PR TITLE
Added an option to enable a secondary glance design

### DIFF
--- a/resources/settings/properties.xml
+++ b/resources/settings/properties.xml
@@ -54,4 +54,9 @@
   -->
   <property id="widget_start_no_tap" type="boolean"></property>
 
+  <!--
+    Enable or disable glance background and right alignment
+  -->
+  <property id="glance_secondary_design" type="boolean"></property>
+
 </properties>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -90,4 +90,13 @@
     />
   </setting>
 
+    <setting
+    propertyKey="@Properties.glance_secondary_design"
+    title="@Strings.SettingsGlanceSecondaryDesign"
+  >
+    <settingConfig
+      type="boolean"
+    />
+  </setting>
+
 </settings>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -47,4 +47,5 @@
     <string id="SettingsUi">Representing types with icons (off) or with labels (on).</string>
     <string id="SettingsTextAlign">Left (off) or Right (on) Menu Alignment.</string>
     <string id="SettingsWidgetStart">(Widget only) Automatically start the application from the widget without waiting for a tap.</string>
+    <string id="SettingsGlanceSecondaryDesign">If enabled, glance won't have blue background and text won't be centered.</string>
 </strings>

--- a/source/HomeAssistantGlanceView.mc
+++ b/source/HomeAssistantGlanceView.mc
@@ -21,12 +21,14 @@
 using Toybox.Lang;
 using Toybox.WatchUi;
 using Toybox.Graphics;
+using Toybox.Application.Properties;
 
 (:glance)
 class HomeAssistantGlanceView extends WatchUi.GlanceView {
-    private static const scLeftMargin = 20; // in pixels
-    private static const scLeftIndent = 10; // Left Indent "_text:" in pixels
-    private static const scMidSep     = 10; // Middle Separator "text:_text" in pixels
+    private static const scLeftMargin            = 20; // in pixels
+    private static const scLeftIndent            = 10; // Left Indent "_text:" in pixels
+    private static const scMidSep                = 10; // Middle Separator "text:_text" in pixels
+    private static const scSecondaryDesignMargin = 5;  // Left Indent in pixels if secondary design for glance is enabled
     private var mApp        as HomeAssistantApp;
     private var mTitle      as WatchUi.Text or Null;
     private var mApiText    as WatchUi.Text or Null;
@@ -40,17 +42,19 @@ class HomeAssistantGlanceView extends WatchUi.GlanceView {
     }
 
     function onLayout(dc as Graphics.Dc) as Void {
-        var strChecking   = WatchUi.loadResource($.Rez.Strings.Checking);
-        var strGlanceMenu = WatchUi.loadResource($.Rez.Strings.GlanceMenu);
-        var h             = dc.getHeight();
-        var tw            = dc.getTextWidthInPixels(strGlanceMenu, Graphics.FONT_XTINY);
+        var strChecking            = WatchUi.loadResource($.Rez.Strings.Checking);
+        var strGlanceMenu          = WatchUi.loadResource($.Rez.Strings.GlanceMenu);
+        var h                      = dc.getHeight();
+        var tw                     = dc.getTextWidthInPixels(strGlanceMenu, Graphics.FONT_XTINY);
+        var apiTextWidth           = dc.getTextWidthInPixels("API", Graphics.FONT_XTINY);
+        var secondaryDesignEnabled = Properties.getValue("glance_secondary_design");
 
         mTitle = new WatchUi.Text({
             :text          => WatchUi.loadResource($.Rez.Strings.AppName),
             :color         => Graphics.COLOR_WHITE,
             :font          => Graphics.FONT_TINY,
             :justification => Graphics.TEXT_JUSTIFY_LEFT | Graphics.TEXT_JUSTIFY_VCENTER,
-            :locX          => scLeftMargin,
+            :locX          => secondaryDesignEnabled ? scSecondaryDesignMargin : scLeftMargin,
             :locY          => 1 * h / 6
         });
 
@@ -58,8 +62,8 @@ class HomeAssistantGlanceView extends WatchUi.GlanceView {
             :text          => "API:",
             :color         => Graphics.COLOR_WHITE,
             :font          => Graphics.FONT_XTINY,
-            :justification => Graphics.TEXT_JUSTIFY_RIGHT | Graphics.TEXT_JUSTIFY_VCENTER,
-            :locX          => scLeftMargin + scLeftIndent + tw,
+            :justification => getTextJustification(secondaryDesignEnabled),
+            :locX          => secondaryDesignEnabled ? scSecondaryDesignMargin : scLeftMargin + scLeftIndent + tw,
             :locY          => 3 * h / 6
         });
         mApiStatus = new WatchUi.Text({
@@ -67,15 +71,15 @@ class HomeAssistantGlanceView extends WatchUi.GlanceView {
             :color         => Graphics.COLOR_WHITE,
             :font          => Graphics.FONT_XTINY,
             :justification => Graphics.TEXT_JUSTIFY_LEFT | Graphics.TEXT_JUSTIFY_VCENTER,
-            :locX          => scLeftMargin + scLeftIndent + scMidSep + tw,
+            :locX          => secondaryDesignEnabled ? scSecondaryDesignMargin + apiTextWidth + scMidSep : scLeftMargin + scLeftIndent + scMidSep + tw,
             :locY          => 3 * h / 6
         });
         mMenuText = new WatchUi.Text({
             :text          => strGlanceMenu + ":",
             :color         => Graphics.COLOR_WHITE,
             :font          => Graphics.FONT_XTINY,
-            :justification => Graphics.TEXT_JUSTIFY_RIGHT | Graphics.TEXT_JUSTIFY_VCENTER,
-            :locX          => scLeftMargin + scLeftIndent + tw,
+            :justification => getTextJustification(secondaryDesignEnabled),
+            :locX          => secondaryDesignEnabled ? scSecondaryDesignMargin : scLeftMargin + scLeftIndent + tw,
             :locY          => 5 * h / 6
         });
         mMenuStatus = new WatchUi.Text({
@@ -83,7 +87,7 @@ class HomeAssistantGlanceView extends WatchUi.GlanceView {
             :color         => Graphics.COLOR_WHITE,
             :font          => Graphics.FONT_XTINY,
             :justification => Graphics.TEXT_JUSTIFY_LEFT | Graphics.TEXT_JUSTIFY_VCENTER,
-            :locX          => scLeftMargin + scLeftIndent + scMidSep + tw,
+            :locX          => secondaryDesignEnabled ? scSecondaryDesignMargin + tw + scMidSep : scLeftMargin + scLeftIndent + scMidSep + tw,
             :locY          => 5 * h / 6
         });
     }
@@ -93,9 +97,10 @@ class HomeAssistantGlanceView extends WatchUi.GlanceView {
         if(dc has :setAntiAlias) {
             dc.setAntiAlias(true);
         }
+        var secondaryDesignEnabled = Properties.getValue("glance_secondary_design");
         dc.setColor(
             Graphics.COLOR_WHITE,
-            Graphics.COLOR_BLUE
+            secondaryDesignEnabled ? Graphics.COLOR_BLACK : Graphics.COLOR_BLUE
         );
         dc.clear();
         mTitle.draw(dc);
@@ -105,5 +110,13 @@ class HomeAssistantGlanceView extends WatchUi.GlanceView {
         mMenuText.draw(dc);
         mMenuStatus.setText(mApp.getMenuStatus());
         mMenuStatus.draw(dc);
+    }
+
+    function getTextJustification(isSecondaryDesignEnabled) {
+        if(isSecondaryDesignEnabled) {
+            return Graphics.TEXT_JUSTIFY_LEFT | Graphics.TEXT_JUSTIFY_VCENTER;
+        } else {
+            return Graphics.TEXT_JUSTIFY_RIGHT | Graphics.TEXT_JUSTIFY_VCENTER;
+        }
     }
 }


### PR DESCRIPTION
I have made some changes to the glance because the old design didn't fit in with all other glances from other apps, and I didn't like that (although the whole app is excellent!).
That is why I created this feature, where you can change the setting `glance_secondary_design,` which (if enabled) will remove the blue background from the glance and make left alignment for all text at a glance (with a little smaller left margin, too).
Here is a screenshot of the glance on Fenix 7S Pro (emulated) with the setting disabled.
<img width="510" alt="Screenshot 2023-12-28 at 10 44 19" src="https://github.com/house-of-abbey/GarminHomeAssistant/assets/21364485/f1322811-7512-49b0-9a54-23f07104395e">
The screenshot of a glance with the setting enabled
<img width="510" alt="Screenshot 2023-12-28 at 10 39 56" src="https://github.com/house-of-abbey/GarminHomeAssistant/assets/21364485/b7a45359-7406-4f30-9a41-b320dd701208">

This is my first contribution to some Connect IQ apps, and I also don't have much professional C experience, so I'm open to any suggestions on improving this feature! Happy holidays!
