### PR TITLE
More responsive status when using a polling delay

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -25,4 +25,4 @@
 |   2.10  | Added a user requested feature to slow down the rate of API calls in order to reduce battery wear for a situation where the application is kept open permanently on the device for convenience. Added 4 new devices. |
 |   2.11  | Bug fix release for menu caching being turned off and language corrections (Czech & Slovenian). |
 |   2.12  | Re-enabled Edge 540 and Edge 840 devices which we are unable to support due to simulator issues, but the Edge 840 device has been confirmed as working by a @Petucky. |
-|   2.13  | Moved the template status queries to Webhooks in order to fix the situation where an account is a non-privileged user. Added telemetry update on activity completion to make automations more timely at the end of an activity. |
+|   2.13  | Moved the template status queries to Webhooks in order to fix the situation where an account is a non-privileged user. Added telemetry update on activity completion to make automations more timely at the end of an activity. When using a polling delay, there is no longer a startup delay for status updates and an action will trigger an immediate round of updates. |

--- a/source/HomeAssistantApp.mc
+++ b/source/HomeAssistantApp.mc
@@ -408,6 +408,20 @@ class HomeAssistantApp extends Application.AppBase {
         }
     }
 
+    // Only call this function if Settings.getPollDelay() > 0. This must be tested locally as it is then efficient to take
+    // alternative action if the test fails.
+    function forceStatusUpdates() as Void {
+        // Don't mess with updates unless we are using a timer.
+        if (Settings.getPollDelay() > 0) {
+            mUpdateTimer.stop();
+            mIsInitUpdateCompl = false;
+            // Start from the beginning, or we will only get a partial round of updates before mIsInitUpdateCompl is flipped.
+            mNextItemToUpdate = 0;
+            // For immediate updates
+            updateNextMenuItem();
+        }
+    }
+
     // We need to spread out the API calls so as not to overload the results queue and cause Communications.BLE_QUEUE_FULL
     // (-101) error. This function is called by a timer every Globals.menuItemUpdateInterval ms.
     function updateNextMenuItemInternal() as Void {

--- a/source/HomeAssistantService.mc
+++ b/source/HomeAssistantService.mc
@@ -80,6 +80,7 @@ class HomeAssistantService {
 
             case 200:
                 // System.println("HomeAssistantService onReturnCall(): Service executed.");
+                getApp().forceStatusUpdates();
                 var d     = data as Lang.Array;
                 var toast = WatchUi.loadResource($.Rez.Strings.Executed) as Lang.String;
                 for(var i = 0; i < d.size(); i++) {

--- a/source/HomeAssistantToggleMenuItem.mc
+++ b/source/HomeAssistantToggleMenuItem.mc
@@ -196,6 +196,8 @@ class HomeAssistantToggleMenuItem extends WatchUi.ToggleMenuItem {
                 break;
 
             case 200:
+                // System.println("HomeAssistantToggleMenuItem onReturnSetState(): Service executed.");
+                getApp().forceStatusUpdates();
                 var state;
                 var d = data as Lang.Array;
                 for(var i = 0; i < d.size(); i++) {


### PR DESCRIPTION
When using a polling delay, an action will trigger an immediate round of updates.