### PR TITLE
Send heartrate, floor, and respiration rate values to Home Assistant

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -24,7 +24,8 @@
 |   2.9   | Added an option to enable confirmation vibration so it can be turned off by request of a user. Removed a redundant setting for the alternative Widget version that was not removed previously, and fixed a bug with dereferencing Null. |
 |   2.10  | Added a user requested feature to slow down the rate of API calls in order to reduce battery wear for a situation where the application is kept open permanently on the device for convenience. Added 4 new devices. |
 |   2.11  | Bug fix release for menu caching being turned off and language corrections (Czech & Slovenian). |
-|   2.12  | Re-enabled Edge 540 and Edge 840 devices which we are unable to support due to simulator issues, but the Edge 840 device has been confirmed as working by a @Petucky. |
+|   2.12  | Re-enabled Edge 540 and Edge 840 devices which we are unable to support due to simulator issues, but the Edge 840 device has been confirmed as working by a [Petucky](https://github.com/Petucky). |
 |   2.13  | Moved the template status queries to Webhooks in order to fix the situation where an account is a non-privileged user. Added telemetry update on activity completion to make automations more timely at the end of an activity. When using a polling delay, there is no longer a startup delay for status updates and an action will trigger an immediate round of updates. |
 |   2.14  | Cautionary bug fix for the background service code where refactorisation spoilt some API level guard clauses. |
 |   2.15  | Better support for templates by isolating erroneous returns and marking the menu item. |
+|   2.16  | Bug fix for lack of phone connection when starting the application. Includes new activity reporting features from [KPWhiver](https://github.com/KPWhiver) covering steps, heart rate, floors climbed and descended, and respiration rate. |

--- a/source/BackgroundServiceDelegate.mc
+++ b/source/BackgroundServiceDelegate.mc
@@ -130,32 +130,38 @@ class BackgroundServiceDelegate extends System.ServiceDelegate {
             {
                 "state"     => System.getSystemStats().battery,
                 "type"      => "sensor",
-                "unique_id" => "battery_level"
+                "unique_id" => "battery_level",
+                "icon"      => "mdi:battery"
             },
             {
                 "state"     => System.getSystemStats().charging,
                 "type"      => "binary_sensor",
-                "unique_id" => "battery_is_charging"
+                "unique_id" => "battery_is_charging",
+                "icon"      => System.getSystemStats().charging ? "mdi:battery-plus" : "mdi:battery-minus"
             },
             {
                 "state"     => activityInfo.steps == null ? "unknown" : activityInfo.steps,
                 "type"      => "sensor",
-                "unique_id" => "steps_today"
+                "unique_id" => "steps_today",
+                "icon"      => "mdi:walk"
             },
             {
                 "state"     => heartRate == null ? "unknown" : heartRate,
                 "type"      => "sensor",
-                "unique_id" => "heart_rate"
+                "unique_id" => "heart_rate",
+                "icon"      => "mdi:heart-pulse"
             },
             {
                 "state"     => activityInfo.floorsClimbed == null ? "unknown" : activityInfo.floorsClimbed,
                 "type"      => "sensor",
                 "unique_id" => "floors_climbed_today",
+                "icon"      => "mdi:stairs-up"
             },
             {
                 "state"     => activityInfo.floorsDescended == null ? "unknown" : activityInfo.floorsDescended,
                 "type"      => "sensor",
                 "unique_id" => "floors_descended_today",
+                "icon"      => "mdi:stairs-down"
             }
         ];
 
@@ -164,6 +170,7 @@ class BackgroundServiceDelegate extends System.ServiceDelegate {
                 "state"     => activityInfo.respirationRate == null ? "unknown" : activityInfo.respirationRate,
                 "type"      => "sensor",
                 "unique_id" => "respiration_rate",
+                "icon"      => "mdi:lungs"
             });
         }
 

--- a/source/BackgroundServiceDelegate.mc
+++ b/source/BackgroundServiceDelegate.mc
@@ -124,6 +124,8 @@ class BackgroundServiceDelegate extends System.ServiceDelegate {
                 method(:onReturnBatteryUpdate)
             );
         }
+        var activityInfo = ActivityMonitor.getInfo();
+        var heartRate = Activity.getActivityInfo().currentHeartRate;
         var data = [
             {
                 "state"     => System.getSystemStats().battery,
@@ -134,8 +136,37 @@ class BackgroundServiceDelegate extends System.ServiceDelegate {
                 "state"     => System.getSystemStats().charging,
                 "type"      => "binary_sensor",
                 "unique_id" => "battery_is_charging"
+            },
+            {
+                "state"     => activityInfo.steps == null ? "unknown" : activityInfo.steps,
+                "type"      => "sensor",
+                "unique_id" => "steps_today"
+            },
+            {
+                "state"     => heartRate == null ? "unknown" : heartRate,
+                "type"      => "sensor",
+                "unique_id" => "heart_rate"
+            },
+            {
+                "state"     => activityInfo.floorsClimbed == null ? "unknown" : activityInfo.floorsClimbed,
+                "type"      => "sensor",
+                "unique_id" => "floors_climbed_today",
+            },
+            {
+                "state"     => activityInfo.floorsDescended == null ? "unknown" : activityInfo.floorsDescended,
+                "type"      => "sensor",
+                "unique_id" => "floors_descended_today",
             }
         ];
+
+        if (ActivityMonitor.Info has :respirationRate) {
+            data.add({
+                "state"     => activityInfo.respirationRate == null ? "unknown" : activityInfo.respirationRate,
+                "type"      => "sensor",
+                "unique_id" => "respiration_rate",
+            });
+        }
+
         if (activity != null) {
             data.add({
                 "state"     => activity,

--- a/source/Settings.mc
+++ b/source/Settings.mc
@@ -70,25 +70,29 @@ class Settings {
         // Manage this inside the application or widget only (not a glance or background service process)
         if (mIsApp) {
             if (mHasService) {
-                mWebhookManager = new WebhookManager();
-                if (getWebhookId().equals("")) {
-                    // System.println("Settings update(): Doing full webhook & sensor creation.");
-                    mWebhookManager.requestWebhookId();
-                } else {
-                    // System.println("Settings update(): Doing just sensor creation.");
-                    // We already have a Webhook ID, so just enable or disable the sensor in Home Assistant.
-                    mWebhookManager.registerWebhookSensors();
-                }
-                if (mIsSensorsLevelEnabled) {
-                    // Create the timed activity
-                    if ((Background.getTemporalEventRegisteredTime() == null) or
-                        (Background.getTemporalEventRegisteredTime() != (mBatteryRefreshRate * 60))) {
-                        Background.registerForTemporalEvent(new Time.Duration(mBatteryRefreshRate * 60)); // Convert to seconds
-                        Background.registerForActivityCompletedEvent();
+                if (System.getDeviceSettings().phoneConnected) {
+                    mWebhookManager = new WebhookManager();
+                    if (getWebhookId().equals("")) {
+                        // System.println("Settings update(): Doing full webhook & sensor creation.");
+                        mWebhookManager.requestWebhookId();
+                    } else {
+                        // System.println("Settings update(): Doing just sensor creation.");
+                        // We already have a Webhook ID, so just enable or disable the sensor in Home Assistant.
+                        mWebhookManager.registerWebhookSensors();
                     }
-                } else if (Background.getTemporalEventRegisteredTime() != null) {
-                    Background.deleteTemporalEvent();
-                    Background.deleteActivityCompletedEvent();
+                    if (mIsSensorsLevelEnabled) {
+                        // Create the timed activity
+                        if ((Background.getTemporalEventRegisteredTime() == null) or
+                            (Background.getTemporalEventRegisteredTime() != (mBatteryRefreshRate * 60))) {
+                            Background.registerForTemporalEvent(new Time.Duration(mBatteryRefreshRate * 60)); // Convert to seconds
+                            Background.registerForActivityCompletedEvent();
+                        }
+                    } else if (Background.getTemporalEventRegisteredTime() != null) {
+                        Background.deleteTemporalEvent();
+                        Background.deleteActivityCompletedEvent();
+                    }
+                } else {
+                    ErrorView.show(WatchUi.loadResource($.Rez.Strings.NoPhone) as Lang.String);
                 }
             } else {
                 // Explicitly disable the background event which persists when the application closes.

--- a/source/Settings.mc
+++ b/source/Settings.mc
@@ -77,18 +77,7 @@ class Settings {
                 } else {
                     // System.println("Settings update(): Doing just sensor creation.");
                     // We already have a Webhook ID, so just enable or disable the sensor in Home Assistant.
-                    // Its a multiple step process, hence starting at step 0.
-                    mWebhookManager.registerWebhookSensor({
-                        "device_class"        => "battery",
-                        "name"                => "Battery Level",
-                        "state"               => System.getSystemStats().battery,
-                        "type"                => "sensor",
-                        "unique_id"           => "battery_level",
-                        "unit_of_measurement" => "%",
-                        "state_class"         => "measurement",
-                        "entity_category"     => "diagnostic",
-                        "disabled"            => !Settings.isSensorsLevelEnabled()
-                    }, 0);
+                    mWebhookManager.registerWebhookSensors();
                 }
                 if (mIsSensorsLevelEnabled) {
                     // Create the timed activity

--- a/source/WebhookManager.mc
+++ b/source/WebhookManager.mc
@@ -217,6 +217,7 @@ class WebhookManager {
                 "state"               => System.getSystemStats().battery,
                 "type"                => "sensor",
                 "unique_id"           => "battery_level",
+                "icon"                => "mdi:battery",
                 "unit_of_measurement" => "%",
                 "state_class"         => "measurement",
                 "entity_category"     => "diagnostic",
@@ -228,6 +229,7 @@ class WebhookManager {
                 "state"           => System.getSystemStats().charging,
                 "type"            => "binary_sensor",
                 "unique_id"       => "battery_is_charging",
+                "icon"            => System.getSystemStats().charging ? "mdi:battery-plus" : "mdi:battery-minus",
                 "entity_category" => "diagnostic",
                 "disabled"        => !Settings.isSensorsLevelEnabled()
             },
@@ -236,7 +238,7 @@ class WebhookManager {
                 "state"       => activityInfo.steps == null ? "unknown" : activityInfo.steps,
                 "type"        => "sensor",
                 "unique_id"   => "steps_today",
-                "icon"        => "mdi:shoe-print",
+                "icon"        => "mdi:walk",
                 "state_class" => "total",
                 "disabled"    => !Settings.isSensorsLevelEnabled()
             },


### PR DESCRIPTION
This change sends the heartrate, respiration rate, stepcount, and floors climbed/descended to Home Assistant as mobile app entities. There are a lot more sensors that could potentially be added.

I have only tested this on a Vivoactive 4s as that is the only device I own.

Let me know what you think and if there are any changes you would like to see.