### PR TITLE
Bug fix for activity reporting

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -29,3 +29,4 @@
 |   2.14  | Cautionary bug fix for the background service code where refactorisation spoilt some API level guard clauses. |
 |   2.15  | Better support for templates by isolating erroneous returns and marking the menu item. |
 |   2.16  | Bug fix for lack of phone connection when starting the application. Includes new activity reporting features from [KPWhiver](https://github.com/KPWhiver) covering steps, heart rate, floors climbed and descended, and respiration rate. |
+|   2.17  | Bug fix for reporting activity metrics that are not found on some devices. |

--- a/source/BackgroundServiceDelegate.mc
+++ b/source/BackgroundServiceDelegate.mc
@@ -150,20 +150,26 @@ class BackgroundServiceDelegate extends System.ServiceDelegate {
                 "type"      => "sensor",
                 "unique_id" => "heart_rate",
                 "icon"      => "mdi:heart-pulse"
-            },
-            {
+            }
+        ];
+
+        if (ActivityMonitor.Info has :floorsClimbed) {
+            data.add({
                 "state"     => activityInfo.floorsClimbed == null ? "unknown" : activityInfo.floorsClimbed,
                 "type"      => "sensor",
                 "unique_id" => "floors_climbed_today",
                 "icon"      => "mdi:stairs-up"
-            },
-            {
+            });
+        }
+
+        if (ActivityMonitor.Info has :floorsDescended) {
+            data.add({
                 "state"     => activityInfo.floorsDescended == null ? "unknown" : activityInfo.floorsDescended,
                 "type"      => "sensor",
                 "unique_id" => "floors_descended_today",
                 "icon"      => "mdi:stairs-down"
-            }
-        ];
+            });
+        }
 
         if (ActivityMonitor.Info has :respirationRate) {
             data.add({

--- a/source/WebhookManager.mc
+++ b/source/WebhookManager.mc
@@ -208,7 +208,8 @@ class WebhookManager {
 
     function registerWebhookSensors() {
         var activityInfo = ActivityMonitor.getInfo();
-        var heartRate = Activity.getActivityInfo().currentHeartRate;
+        var heartRate    = Activity.getActivityInfo().currentHeartRate;
+        var unavailable  = WatchUi.loadResource($.Rez.Strings.Unavailable) as Lang.String;
 
         var sensors = [
             {
@@ -224,59 +225,64 @@ class WebhookManager {
                 "disabled"            => !Settings.isSensorsLevelEnabled()
             },
             {
-                "device_class"    => "battery_charging",
-                "name"            => "Battery is Charging",
-                "state"           => System.getSystemStats().charging,
-                "type"            => "binary_sensor",
-                "unique_id"       => "battery_is_charging",
-                "icon"            => System.getSystemStats().charging ? "mdi:battery-plus" : "mdi:battery-minus",
-                "entity_category" => "diagnostic",
-                "disabled"        => !Settings.isSensorsLevelEnabled()
+                "device_class"        => "battery_charging",
+                "name"                => "Battery is Charging",
+                "state"               => System.getSystemStats().charging,
+                "type"                => "binary_sensor",
+                "unique_id"           => "battery_is_charging",
+                "icon"                => System.getSystemStats().charging ? "mdi:battery-plus" : "mdi:battery-minus",
+                "entity_category"     => "diagnostic",
+                "disabled"            => !Settings.isSensorsLevelEnabled()
             },
             {
-                "name"        => "Steps today",
-                "state"       => activityInfo.steps == null ? "unknown" : activityInfo.steps,
-                "type"        => "sensor",
-                "unique_id"   => "steps_today",
-                "icon"        => "mdi:walk",
-                "state_class" => "total",
-                "disabled"    => !Settings.isSensorsLevelEnabled()
+                "name"                => "Steps today",
+                "state"               => activityInfo.steps == null ? unavailable : activityInfo.steps,
+                "type"                => "sensor",
+                "unique_id"           => "steps_today",
+                "icon"                => "mdi:walk",
+                "state_class"         => "total",
+                "disabled"            => !Settings.isSensorsLevelEnabled()
             },
             {
                 "name"                => "Heart rate",
-                "state"               => heartRate == null ? "unknown" : heartRate,
+                "state"               => heartRate == null ? unavailable : heartRate,
                 "type"                => "sensor",
                 "unique_id"           => "heart_rate",
                 "icon"                => "mdi:heart-pulse",
                 "unit_of_measurement" => "bpm",
                 "state_class"         => "measurement",
                 "disabled"            => !Settings.isSensorsLevelEnabled()
-            },
-            {
-                "name"        => "Floors climbed today",
-                "state"       => activityInfo.floorsClimbed == null ? "unknown" : activityInfo.floorsClimbed,
-                "type"        => "sensor",
-                "unique_id"   => "floors_climbed_today",
-                "icon"        => "mdi:stairs-up",
-                "state_class" => "total",
-                "disabled"    => !Settings.isSensorsLevelEnabled()
-            },
-            {
-                "name"        => "Floors descended today",
-                "state"       => activityInfo.floorsDescended == null ? "unknown" : activityInfo.floorsDescended,
-                "type"        => "sensor",
-                "unique_id"   => "floors_descended_today",
-                "icon"        => "mdi:stairs-down",
-                "state_class" => "total",
-                "disabled"    => !Settings.isSensorsLevelEnabled()
             }
         ];
 
+        if (ActivityMonitor.Info has :floorsClimbed) {
+            sensors.add({
+                "name"                => "Floors climbed today",
+                "state"               => activityInfo.floorsClimbed == null ? unavailable : activityInfo.floorsClimbed,
+                "type"                => "sensor",
+                "unique_id"           => "floors_climbed_today",
+                "icon"                => "mdi:stairs-up",
+                "state_class"         => "total",
+                "disabled"            => !Settings.isSensorsLevelEnabled()
+            });
+        }
+
+        if (ActivityMonitor.Info has :floorsDescended) {
+            sensors.add({
+                "name"                => "Floors descended today",
+                "state"               => activityInfo.floorsDescended == null ? unavailable : activityInfo.floorsDescended,
+                "type"                => "sensor",
+                "unique_id"           => "floors_descended_today",
+                "icon"                => "mdi:stairs-down",
+                "state_class"         => "total",
+                "disabled"            => !Settings.isSensorsLevelEnabled()
+            });
+        }
 
         if (ActivityMonitor.Info has :respirationRate) {
             sensors.add({
                 "name"                => "Respiration rate",
-                "state"               => activityInfo.respirationRate == null ? "unknown" : activityInfo.respirationRate,
+                "state"               => activityInfo.respirationRate == null ? unavailable : activityInfo.respirationRate,
                 "type"                => "sensor",
                 "unique_id"           => "respiration_rate",
                 "icon"                => "mdi:lungs",
@@ -287,14 +293,15 @@ class WebhookManager {
         }
 
         if (Activity has :getProfileInfo) {
-            var activity = Activity.getProfileInfo().sport;
+            var activity     = Activity.getProfileInfo().sport;
             var sub_activity = Activity.getProfileInfo().subSport;
+
             if ((Activity.getActivityInfo() != null) and
                 ((Activity.getActivityInfo().elapsedTime == null) or
                     (Activity.getActivityInfo().elapsedTime == 0))) {
                 // Indicate no activity with -1, not part of Garmin's activity codes.
                 // https://developer.garmin.com/connect-iq/api-docs/Toybox/Activity.html#Sport-module
-                activity = -1;
+                activity     = -1;
                 sub_activity = -1;
             }
             sensors.add({

--- a/source/WebhookManager.mc
+++ b/source/WebhookManager.mc
@@ -209,7 +209,6 @@ class WebhookManager {
     function registerWebhookSensors() {
         var activityInfo = ActivityMonitor.getInfo();
         var heartRate    = Activity.getActivityInfo().currentHeartRate;
-        var unavailable  = WatchUi.loadResource($.Rez.Strings.Unavailable) as Lang.String;
 
         var sensors = [
             {
@@ -236,7 +235,7 @@ class WebhookManager {
             },
             {
                 "name"                => "Steps today",
-                "state"               => activityInfo.steps == null ? unavailable : activityInfo.steps,
+                "state"               => activityInfo.steps == null ? "unknown" : activityInfo.steps,
                 "type"                => "sensor",
                 "unique_id"           => "steps_today",
                 "icon"                => "mdi:walk",
@@ -245,7 +244,7 @@ class WebhookManager {
             },
             {
                 "name"                => "Heart rate",
-                "state"               => heartRate == null ? unavailable : heartRate,
+                "state"               => heartRate == null ? "unknown" : heartRate,
                 "type"                => "sensor",
                 "unique_id"           => "heart_rate",
                 "icon"                => "mdi:heart-pulse",
@@ -258,7 +257,7 @@ class WebhookManager {
         if (ActivityMonitor.Info has :floorsClimbed) {
             sensors.add({
                 "name"                => "Floors climbed today",
-                "state"               => activityInfo.floorsClimbed == null ? unavailable : activityInfo.floorsClimbed,
+                "state"               => activityInfo.floorsClimbed == null ? "unknown" : activityInfo.floorsClimbed,
                 "type"                => "sensor",
                 "unique_id"           => "floors_climbed_today",
                 "icon"                => "mdi:stairs-up",
@@ -270,7 +269,7 @@ class WebhookManager {
         if (ActivityMonitor.Info has :floorsDescended) {
             sensors.add({
                 "name"                => "Floors descended today",
-                "state"               => activityInfo.floorsDescended == null ? unavailable : activityInfo.floorsDescended,
+                "state"               => activityInfo.floorsDescended == null ? "unknown" : activityInfo.floorsDescended,
                 "type"                => "sensor",
                 "unique_id"           => "floors_descended_today",
                 "icon"                => "mdi:stairs-down",
@@ -282,7 +281,7 @@ class WebhookManager {
         if (ActivityMonitor.Info has :respirationRate) {
             sensors.add({
                 "name"                => "Respiration rate",
-                "state"               => activityInfo.respirationRate == null ? unavailable : activityInfo.respirationRate,
+                "state"               => activityInfo.respirationRate == null ? "unknown" : activityInfo.respirationRate,
                 "type"                => "sensor",
                 "unique_id"           => "respiration_rate",
                 "icon"                => "mdi:lungs",


### PR DESCRIPTION
Added 'has' clauses around additional ActivityMonitor.Info fields that are not present on all devices. I have also checked the other reporting fields to ensure they are not device dependent.