### PR TITLE
227 enhancement glance info cachingprevious results instead of unconfigured

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -39,3 +39,4 @@
 |   2.24  | Experiment to prevent new Webhook IDs being created unnecessarily. Reduced the latency for the first menu update. Added 4 new devices: approachs50, descentg2, descentmk1, and gpsmap66. |
 |   2.25  | 2 Bug fixes. First time startup issues caused by v2.24 change and a fix for pure numbers in returned templates. |
 |   2.26  | Retry responsive menu fix failed in v2.24. Cosmetic internal class changes. |
+|   2.27  | Trivial bug fix for the glance view to prevent the "Unconfigured" result being erroneously displayed because the settings were not yet pulled from persistent storage. |

--- a/source/HomeAssistantApp.mc
+++ b/source/HomeAssistantApp.mc
@@ -212,7 +212,7 @@ class HomeAssistantApp extends Application.AppBase {
     // asynchronous and affects how the views are managed.
     (:glance)
     function fetchMenuConfig() as Lang.Boolean {
-        // System.println("URL = " + Settings.getConfigUrl());
+        // System.println("Menu URL = " + Settings.getConfigUrl());
         if (Settings.getConfigUrl().equals("")) {
             mMenuStatus = WatchUi.loadResource($.Rez.Strings.Unconfigured) as Lang.String;
             WatchUi.requestUpdate();
@@ -468,6 +468,7 @@ class HomeAssistantApp extends Application.AppBase {
 
     (:glance)
     function fetchApiStatus() as Void {
+        // System.println("API URL = " + Settings.getApiUrl());
         if (Settings.getApiUrl().equals("")) {
             mApiStatus = WatchUi.loadResource($.Rez.Strings.Unconfigured) as Lang.String;
             WatchUi.requestUpdate();
@@ -546,8 +547,8 @@ class HomeAssistantApp extends Application.AppBase {
         mIsGlance   = true;
         mApiStatus  = WatchUi.loadResource($.Rez.Strings.Checking) as Lang.String;
         mMenuStatus = WatchUi.loadResource($.Rez.Strings.Checking) as Lang.String;
-        updateStatus();
         Settings.update();
+        updateStatus();
         mGlanceTimer = new Timer.Timer();
         mGlanceTimer.start(method(:updateStatus), Globals.scApiBackoff, true);
         return [new HomeAssistantGlanceView(self)];


### PR DESCRIPTION
Not as the issue requested, but instead pulling the settings from persistent storage before checking the URL status, preventing "Unconfigured" being initially displayed when it should be "Checking..." as coded.