### PR TITLE
Add TLS 1.2 compatibility guidance for Garmin Wi-Fi/LTE connection issues

### DIFF
--- a/Wi-Fi.md
+++ b/Wi-Fi.md
@@ -16,6 +16,11 @@ With version 3.0 onwards the application now includes the ability to temporarily
 
 4. Remember that you need to be within range of your watch's configured Wi-Fi access point to utilize this functionality. If supported by your device, LTE offers a longer range, but network charges may apply.
 
+5. On some Garmin devices, the HTTPS handshake is performed using **TLS 1.2**. If your server or proxy enforces a higher minimum (e.g., TLS 1.3), you will encounter an SSL handshake error with the message: `HTTP request returned error code = 0`
+To fix this, lower the minimum TLS setting to allow TLS 1.2. For example, if you are using **Cloudflare Tunneling**, go to:  
+`SSL/TLS → Edge Certificates → Minimum TLS Version`  
+and set it to **at most TLS 1.2**. _Reducing below TLS 1.2 is not recommended due to security risks._
+
 ## Video
 
 This video using will hopefully make it obvious how slow it is to use the Wi-Fi option and illustrate the cautionary notes above.


### PR DESCRIPTION
This update adds a note to the “Limits of Use” section explaining that some Garmin devices use TLS 1.2 for HTTPS handshakes. If a server or proxy enforces a minimum TLS version of 1.3 or higher, users may experience SSL handshake errors with the message HTTP request returned error code = 0.

The documentation now includes:

An explanation of the issue

How to identify the error

A practical solution example for Cloudflare Tunneling users to lower the minimum TLS version to 1.2

A security note advising against lowering TLS below 1.2

This helps users troubleshoot connectivity problems when using Wi-Fi or LTE features on Garmin watches with Home Assistant.