### PR TITLE
Update config.schema.json

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -18,7 +18,6 @@
     }
   },
   "required": [
-    "title",
     "items"
   ],
   "additionalProperties": false,
@@ -231,7 +230,6 @@
       },
       "required": [
         "name",
-        "title",
         "type",
         "items"
       ],


### PR DESCRIPTION
Removed the need to specify any menu titles. The code works with a `Null` as-is. I'm not convinced the lack of a title saves screen space as desired, but the code works without a title, there's no real reason to specify one as its not essential, so perhaps we just relax the schema?

There is one user requesting this. They can work with a schema warning for now and this can be rolled into the next release, when there's more changes.