### PR TITLE
Preserve tap action data for numeric picker actions

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -256,6 +256,11 @@
                 "action": {
                   "$ref": "#/$defs/action"
                 },
+                "data": {
+                  "type": "object",
+                  "title": "Additional action data",
+                  "description": "Fixed Home Assistant service data. The selected picker value is merged into this object using the picker's data_attribute. Service-specific fields cannot be schema checked here."
+                },
                 "picker": {
                   "type": "object",
                   "title": "Number picker configuration",

--- a/examples/Numeric.md
+++ b/examples/Numeric.md
@@ -39,6 +39,36 @@ Field            | Purpose                                                      
 
 It may well be the case that often `attribute` and `data_attribute` are the same attribute, as with this example.
 
+## Additional Action Data
+
+The `tap_action` object may also include a `data` object for fixed service call parameters. When the picker value is selected, the application merges the picker value into this `data` object using `data_attribute`.
+
+For example, a light brightness picker can request a HomeAssistant transition while still using the picker value for `brightness`.
+
+```json
+{
+  "name": "Lounge Brightness",
+  "content": "{{ ((state_attr('light.lounge','brightness') | int(0) / 255) * 100) | round(0) }}%",
+  "type": "numeric",
+  "entity": "light.lounge",
+  "tap_action": {
+    "action": "light.turn_on",
+    "data": {
+      "transition": 2
+    },
+    "picker": {
+      "step": 5,
+      "min": 0,
+      "max": 255,
+      "attribute": "brightness",
+      "data_attribute": "brightness"
+    }
+  }
+}
+```
+
+The resulting action data sent to HomeAssistant contains both the fixed `transition` value and the selected `brightness` value.
+
 ## Helper
 
 You might define a "helper" entity as follows in HomeAssistant:

--- a/source/HomeAssistantMenuItemFactory.mc
+++ b/source/HomeAssistantMenuItemFactory.mc
@@ -163,6 +163,7 @@ class HomeAssistantMenuItemFactory {
         entity_id as Lang.String?,
         template  as Lang.String?,
         action    as Lang.String?,
+        data      as Lang.Dictionary?,
         picker    as Lang.Dictionary,
         options   as {
             :exit    as Lang.Boolean,
@@ -171,9 +172,12 @@ class HomeAssistantMenuItemFactory {
             :icon    as WatchUi.Bitmap
         }
     ) as WatchUi.MenuItem {
-        var data = null;
         if (entity_id != null) {
-            data = { "entity_id" => entity_id };
+            if (data == null) {
+                data = { "entity_id" => entity_id };
+            } else {
+                data["entity_id"] = entity_id;
+            }
         }
         var keys = mMenuItemOptions.keys();
         for (var i = 0; i < keys.size(); i++) {

--- a/source/HomeAssistantNumericMenuItem.mc
+++ b/source/HomeAssistantNumericMenuItem.mc
@@ -155,7 +155,10 @@ class HomeAssistantNumericMenuItem extends HomeAssistantMenuItem {
     //
     function onConfirm(b as Lang.Boolean) as Void {
         var dataAttribute = mPicker["data_attribute"] as Lang.String?;
-        var entity_id     = mData["entity_id"]        as Lang.String?;
+        var entity_id     = null                      as Lang.String?;
+        if (mData != null) {
+            entity_id = mData["entity_id"] as Lang.String?;
+        }
 
         WatchUi.popView(WatchUi.SLIDE_RIGHT);
         WatchUi.requestUpdate();
@@ -164,12 +167,18 @@ class HomeAssistantNumericMenuItem extends HomeAssistantMenuItem {
             return;
         }
         if (mAction != null) {
+            var data = {} as Lang.Dictionary;
+            if (mData != null) {
+                var keys = mData.keys();
+                for (var i = 0; i < keys.size(); i++) {
+                    data[keys[i]] = mData[keys[i]];
+                }
+            }
+            data["entity_id"] = entity_id.toString();
+            data[dataAttribute.toString()] = mValue;
             mHomeAssistantService.call(
                 mAction,
-                {
-                    "entity_id"              => entity_id.toString(),
-                    dataAttribute.toString() => mValue
-                },
+                data,
                 mExit
             );
         }

--- a/source/HomeAssistantView.mc
+++ b/source/HomeAssistantView.mc
@@ -141,6 +141,7 @@ class HomeAssistantView extends WatchUi.Menu2 {
                                     entity,
                                     content,
                                     action,
+                                    data,
                                     picker,
                                     {
                                         :exit    => exit,


### PR DESCRIPTION
Numeric menu items currently discard existing `tap_action.data` when confirming a picker value. This prevents service call options such as `transition` from being sent with `light.turn_on`.

This change passes `tap_action.data` into numeric menu items and merges that data with the selected numeric picker value before calling the Home Assistant service.

Example fixed payload:

```json
{
  "entity_id": "light.living_room",
  "transition": 2,
  "brightness": 128
}

Tested with a Forerunner 965 build and a Home Assistant light brightness numeric picker.